### PR TITLE
docs: create reference landing page and link from overview

### DIFF
--- a/docs/mmoverview.md
+++ b/docs/mmoverview.md
@@ -1,1 +1,31 @@
+# Welcome to the MealMeate API
 
+**Cook smarter, not harder.**
+
+The MealMate RESTful API is a powerful yet simple tool designed to help users and developers alike tackle the everyday challenge of meal planning. It provides programmatic access to a database of recipes, ingredients, and pre-designed meal plans. Whether you're looking to suggest a quick dinner based on ingredients on hand, help users browse pantry staples, or generate comprehensive weekly meal plans, the MealMate API offers the data and functionality you need.
+
+## Why Use the MealMate API?
+
+You can leverage the MealMate API to build a variety of applications and features, such as:
+
+* **Recipe suggestion engines**
+
+>>> Create tools that suggest recipes baed on ingredients your users already have, minimizing food waste and inspiring new meal ideas.
+
+* **Dietary and heath apps**
+
+>>>Integrate meal planning and recipe discovery tailored to preparation time constraints and specific dietary need, including vegetarian, vegan, and high-protein.
+
+* **Smart grocery list generators**
+
+>>>Develop applications that automatically compile grocery lists based on selected recipes or entire meal plans.
+
+* **Content enhancement for food blogs or websites**
+
+>>>Dynamically display relevant recipes or ingredient information to enrich user experience.
+
+* **Educational cooking platforms**
+
+>>>Provide beginners with simple recipes and ingredient information to help them learn to cook.
+
+[Get Started](./mmget-started.md) | [Tutorial](./mmtutorial.md) | [Reference](./mmref.md)

--- a/docs/mmref.md
+++ b/docs/mmref.md
@@ -1,0 +1,10 @@
+# Endpoint References (draft)
+
+Explore the meal planning, recipe, and ingredient information the MealMate API provides using these endpoints:
+
+* GET /ingredients
+* GET /ingredients/{id}
+* GET /recipes
+* GET /recipes/{id}
+* GET /plans
+* GET /plans/{id}


### PR DESCRIPTION
This commit establishes the initial structure for the API reference documentation.

- Creates the placeholder mmref.md file for the future API reference landing page.
- Adds a relative link from the mmoverview.md homepage to the new reference page.