### PR TITLE
docs: create initial files for all API endpoints and landing page

### DIFF
--- a/docs/mmGET-ingredients-id.md
+++ b/docs/mmGET-ingredients-id.md
@@ -1,0 +1,3 @@
+# GET /ingredients/{id}
+
+Placeholder text.

--- a/docs/mmGET-ingredients.md
+++ b/docs/mmGET-ingredients.md
@@ -1,0 +1,3 @@
+# GET /ingredients
+
+Placeholder text.

--- a/docs/mmGET-plans-id.md
+++ b/docs/mmGET-plans-id.md
@@ -1,0 +1,3 @@
+# GET /plans/{id}
+
+Placeholder text.

--- a/docs/mmGET-plans.md
+++ b/docs/mmGET-plans.md
@@ -1,0 +1,3 @@
+# GET /plans
+
+Placeholder text.

--- a/docs/mmGET-recipes-id.md
+++ b/docs/mmGET-recipes-id.md
@@ -1,0 +1,3 @@
+# GET /recipes/{id}
+
+Placeholder text.

--- a/docs/mmGET-recipes.md
+++ b/docs/mmGET-recipes.md
@@ -1,0 +1,3 @@
+# GET /recipes
+
+Placeholder text


### PR DESCRIPTION
Adds placeholder markdown files for reference landing page and the six primary API endpoints: /recipes, /recipes/{id}, /ingredients, /ingredients/{id}, /plans, and /plans/{id}.